### PR TITLE
Fix use after free in neighbors, spring_attachments and cell attack

### DIFF
--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -1207,6 +1207,9 @@ void delete_cell( int index )
 	// released internalized substrates (as of 1.5.x releases)
 	pDeleteMe->release_internalized_substrates(); 
 
+	// new Dec 2, 2025
+	pDeleteMe->remove_self_from_attackers(); 
+	
 	// performance goal: don't delete in the middle -- very expensive reallocation
 	// alternative: copy last element to index position, then shrink vector by 1 at the end O(constant)
 
@@ -3433,6 +3436,16 @@ void Cell::remove_all_spring_attachments( void )
 	return; 
 }
 
+void Cell::remove_self_from_attackers( void )
+{
+	#pragma omp parallel for
+	for (int j=0; j < all_cells->size(); j++) 
+	{
+		if (j != index && (*all_cells)[j]->phenotype.cell_interactions.pAttackTarget != NULL && (*all_cells)[j]->phenotype.cell_interactions.pAttackTarget == this) {
+			(*all_cells)[j]->phenotype.cell_interactions.pAttackTarget = NULL;
+		}
+	}
+}
 
 void attach_cells( Cell* pCell_1, Cell* pCell_2 )
 {

--- a/core/PhysiCell_cell.cpp
+++ b/core/PhysiCell_cell.cpp
@@ -3404,6 +3404,25 @@ void Cell::remove_self_from_all_neighbors( void )
 			else
 			{ /* future error message */  }
 	}
+	
+	// This is a bit of a ugly hack, we need to find the origin of that bug
+	#pragma omp parallel for 
+	for ( int i = 0; i < all_cells->size(); i++ )
+	{
+		Cell* pC = (*all_cells)[i];
+		if (pC != this)
+		{
+			auto SearchResult = std::find( 
+			pC->state.neighbors.begin(),pC->state.neighbors.end(),this );
+			if ( SearchResult != pC->state.neighbors.end() )
+			{
+				std::cout << "Cell " << pC->ID << " still has cell " << this->ID << " as a neighbor!" << std::endl;
+				pC->state.neighbors.erase( SearchResult ); 
+			}
+		
+		}
+	}
+
 
 	return; 
 }
@@ -3433,6 +3452,25 @@ void Cell::remove_all_spring_attachments( void )
 		// clear my list 
 		state.spring_attachments.clear(); 
 	}
+	
+	// This is a bit of a ugly hack, we need to find the origin of that bug
+	#pragma omp parallel for 
+	for ( int i = 0; i < all_cells->size(); i++ )
+	{
+		Cell* pC = (*all_cells)[i];
+		if (pC != this)
+		{
+			auto SearchResult = std::find( 
+			pC->state.spring_attachments.begin(),pC->state.spring_attachments.end(),this );
+			if ( SearchResult != pC->state.spring_attachments.end() )
+			{
+				std::cout << "Cell " << pC->ID << " still has cell " << this->ID << " as a spring attachment!" << std::endl;
+				pC->state.spring_attachments.erase( SearchResult ); 
+			}
+		
+		}
+	}
+	
 	return; 
 }
 

--- a/core/PhysiCell_cell.h
+++ b/core/PhysiCell_cell.h
@@ -238,6 +238,7 @@ class Cell : public Basic_Agent
 	void attach_cell_as_spring( Cell* pAddMe ); // done 
 	void detach_cell_as_spring( Cell* pRemoveMe ); // done 
 	void remove_all_spring_attachments( void ); // done 
+	void remove_self_from_attackers( void ); 
 
 	// I want to eventually deprecate this, by ensuring that 
 	// critical BioFVM and PhysiCell data elements are synced when they are needed 


### PR DESCRIPTION
I had some crash that I wanted to fix for a while, and finally found the issues:

- pAttackTarget is not cleaned when the target is deleted, resulting in a use after free
- neighbors are not always symmetrical, but when we delete a cell we suppose they are, resulting in a use after free
- spring_attachments are not always symmetrical, but when we delete a cell we suppose they are, resulting in a use after free. 

Here the fixes I'm proposing for now: 
- When deleting a cell, I check that no other cell has it as an attack target and remove it if so
- When deleting a cell, after removing it from its known neighbors, check every cell to remove from unknown (non-symmetrical) neighbors
- When deleting a cell, after removing it from its known spring_attachments, check every cell to remove from unknown (non-symmetrical) spring_attachments

Clearly, this can be improved, but it fixes the present issues.